### PR TITLE
Improve date parser

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -63,6 +63,7 @@ History
 * Added inicheck to traviCI and Coveralls
 * Fixes for 35_ , 38_ , 39_, 40_, 41_, 42_ 43_, 44_, 45_
 * Added in linting with isort and autopep8
+* Hardcoded `parse_date` to always use UTC and return timezone unaware object. 51_
 
 .. _35: https://github.com/USDA-ARS-NWRC/inicheck/issues/25
 .. _38: https://github.com/USDA-ARS-NWRC/inicheck/issues/27
@@ -73,3 +74,4 @@ History
 .. _43: https://github.com/USDA-ARS-NWRC/inicheck/issues/43
 .. _44: https://github.com/USDA-ARS-NWRC/inicheck/issues/44
 .. _45: https://github.com/USDA-ARS-NWRC/inicheck/issues/45
+.. _51: https://github.com/USDA-ARS-NWRC/inicheck/issues/51

--- a/docs/master_config.rst
+++ b/docs/master_config.rst
@@ -251,9 +251,9 @@ The following example shows a recipe:
 
 1. The section name here is identified as a recipe by having the recipe in the name.
 2. The trigger is identified by having a name with the word trigger in it and is
-triggered when the user's configuration file has a the section csv.
+   triggered when the user's configuration file has a the section csv.
 3. If the test_trigger condition is met then all the defaults will be applied to
-the csv section in the user's configuration file because of the keyword
-**apply_defaults**
+   the csv section in the user's configuration file because of the keyword
+   **apply_defaults**
 4. If the users config file contains the sections **mysql** and or **gridded** then
-they will be removed due to the keywords **remove_section**
+   they will be removed due to the keywords **remove_section**

--- a/docs/master_config.rst
+++ b/docs/master_config.rst
@@ -83,7 +83,13 @@ nearest, linear, or cubic.
             options = [nearest linear cubic],
             description = interpolation method to use for this variable
 
-**NOTE on paths**: All paths (filenames and directories) in inicheck are
+Notes on Types
+^^^^^^^^^^^^^^
+
+Paths
++++++
+
+All paths (filenames and directories) in inicheck are
 assumed to be either relative to the config file or absolute. e.g.
 
 .. code-block:: ini
@@ -99,7 +105,10 @@ This will default to a path up one directory from the location of the config.
 Any path options with critical prepended just means that inicheck will throw
 an error instead of a warning.
 
-**NOTE on lists**: Listed input checking can be performed. To assign a type
+Lists
++++++
+
+Listed input checking can be performed. To assign a type
 as a list, simply add the keyword list to the type name. This will force the
 output to be a list and still check every entry in a provided list. To provide
 a list in inicheck master configs use bracketed space separated lists. An
@@ -112,6 +121,36 @@ example of adding the list keyword and a list default is below
           default = [01-01 04-01 07-01 10-01] ,
           type = datetimelist
           description = List of datetimes to plot up for earnings
+
+
+Dates
++++++
+
+All datetime types will be checked by the |dateparser_link| library, whether
+the given string can be converted into a valid datetime object. All dates
+given are assumed to be in UTC timezone. Dates can be given in any combination
+that the library supports.
+
+Care must be taken when there is a timezone given.
+For instance:
+
+.. code-block::
+
+  2020-01-01 00:00 MST
+
+will be parsed using the UTC timezone and results in
+
+.. code-block::
+
+  2020-01-01 07:00
+
+The returned datetime object will be timezone unaware.
+
+.. |dateparser_link| raw:: html
+
+  <a href="https://dateparser.readthedocs.io/en/latest/" target="_blank">
+    dateparser
+  </a>
 
 Recipes
 --------

--- a/docs/master_config.rst
+++ b/docs/master_config.rst
@@ -58,9 +58,6 @@ Available Types
 Each entry in the master config file can provide a type. If no type is provided,
 then the default is type string.
 
-**Note**: Any path options with critical prepended just means that inicheck will
-throw an error instead of a warning.
-
 Available types:
 
   * Bool - :class:`~inicheck.checkers.CheckBool`
@@ -86,7 +83,7 @@ nearest, linear, or cubic.
             options = [nearest linear cubic],
             description = interpolation method to use for this variable
 
-**NOTE ON PATHS**: All paths (filenames and directories) in inicheck are
+**NOTE on paths**: All paths (filenames and directories) in inicheck are
 assumed to be either relative to the config file or absolute. e.g.
 
 .. code-block:: ini
@@ -99,8 +96,10 @@ assumed to be either relative to the config file or absolute. e.g.
 
 This will default to a path up one directory from the location of the config.
 
+Any path options with critical prepended just means that inicheck will throw
+an error instead of a warning.
 
-**Notes on lists**: Listed input checking can be performed. To assign a type
+**NOTE on lists**: Listed input checking can be performed. To assign a type
 as a list, simply add the keyword list to the type name. This will force the
 output to be a list and still check every entry in a provided list. To provide
 a list in inicheck master configs use bracketed space separated lists. An

--- a/inicheck/utilities.py
+++ b/inicheck/utilities.py
@@ -10,8 +10,8 @@ def parse_date(value):
     Uses the `dateparser` library for String objects.
 
     All strings will be parsed in UTC timezone, but returned value will be
-    timezone unaware. Hardcoded timezone enables parsing of dates independent
-    of the timezone set with the operating system.
+    timezone unaware. Hardcoded timezone setting to UTC for dateparser enables
+    parsing of dates independent of the timezone set with the operating system.
 
     Args:
         value: string or date object

--- a/inicheck/utilities.py
+++ b/inicheck/utilities.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from datetime import date, datetime
 
 import dateparser
@@ -7,13 +6,17 @@ import dateparser
 
 def parse_date(value):
     """
-    Function used to cast items to datetime from string. Meant to prevent the
-    importing of pandas just for the to_datetime function.
+    Function used to cast value to datetime from String or date objects.
+    Uses the `dateparser` library for String objects.
+
+    All strings will be parsed in UTC timezone, but returned value will be
+    timezone unaware. Hardcoded timezone enables parsing of dates independent
+    of the timezone set with the operating system.
 
     Args:
-        value: string of a datetime
+        value: string or date object
     Returns:
-        converted: Datetime object representing the value passed.
+        converted: Datetime object of given value
     """
 
     if isinstance(value, datetime):
@@ -23,7 +26,13 @@ def parse_date(value):
         return datetime(value.year, value.month, value.day)
 
     else:
-        converted = dateparser.parse(value, settings={'STRICT_PARSING': True})
+        converted = dateparser.parse(
+            value, settings={
+                'STRICT_PARSING': True,
+                'TIMEZONE': 'UTC',
+                'RETURN_AS_TIMEZONE_AWARE': False
+            }
+        )
         if converted is None:
             raise TypeError("{} is not a date".format(value))
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,7 +8,6 @@ Tests for `inicheck.utilities` module.
 """
 
 import unittest
-from datetime import date, datetime
 
 from inicheck.tools import get_user_config
 from inicheck.utilities import *
@@ -18,9 +17,10 @@ class TestUtilities(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         base = os.path.dirname(__file__)
-        self.ucfg = get_user_config(os.path.join(base,
-                                                 "test_configs/full_config.ini"),
-                                    modules="inicheck")
+        self.ucfg = get_user_config(
+            os.path.join(base,"test_configs/full_config.ini"),
+            modules="inicheck"
+        )
 
     def test_remove_comments(self):
         """
@@ -29,7 +29,8 @@ class TestUtilities(unittest.TestCase):
         values = {"test": "test#comment",
                   "test1": "test1;comment",
                   "": ";full in line comment",
-                  "testboth": "testboth; test a comment with both types of # comments "}
+                  "testboth": "testboth; test a comment with both "
+                              "types of # comments "}
         for k, v in values.items():
             out = remove_comment(v)
 
@@ -71,8 +72,8 @@ class TestUtilities(unittest.TestCase):
 
     def test_find_options_in_recipes(self):
         """
-        Tests utilites.find_options_in_recipes which extracts choices being
-        nade by looking at the recipes and determining which work on each other
+        Tests utilities.find_options_in_recipes which extracts choices being
+        made by looking at the recipes and determining which work on each other
         such that they don't exist at the same time. Used in the inimake cli
         """
         mcfg = self.ucfg.mcfg

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -161,7 +161,9 @@ class TestUtilities(unittest.TestCase):
             master_files=None)
         assert cmd == 'inicheck -f {} -m inicheck'.format(self.ucfg.filename)
 
-    def test_parse_date_str(self):
+
+class TestUtilitiesDateParse(TestUtilities):
+    def test_string_date_only(self):
         """
         Test the parse_date function which is used in the checks for datetime
         """
@@ -173,22 +175,16 @@ class TestUtilities(unittest.TestCase):
         value = parse_date(value)
         self.assertEqual(datetime(2019, 10, 1, 10), value)
 
-    def test_parse_date_fails_int(self):
-        with self.assertRaises(TypeError):
-            parse_date(10)
-
-    def test_parse_date_fails_with_unknown_string(self):
-        with self.assertRaises(TypeError):
-            parse_date("10 F")
-
-    def test_date_parse_in_utc(self):
+    def test_string_with_tz_info_in_utc(self):
         value = parse_date("2019-10-1 10:00 MST")
-        value = parse_date(value)
         self.assertEqual(datetime(2019, 10, 1, 17), value)
 
-    def test_date_parse_returns_tz_unaware(self):
+    def test_tz_unaware_return(self):
+        value = parse_date("2019-10-1 10:00")
+        self.assertIsNone(value.tzinfo)
+
+    def test_tz_unaware_return_with_tz_info_given(self):
         value = parse_date("2019-10-1 10:00 MST")
-        value = parse_date(value)
         self.assertIsNone(value.tzinfo)
 
     def test_parse_date_datetime(self):
@@ -201,6 +197,14 @@ class TestUtilities(unittest.TestCase):
         expected = datetime(2019, 10, 1)
         value = parse_date(to_convert)
         self.assertEqual(value, expected)
+
+    def test_parse_date_fails_int(self):
+        with self.assertRaises(TypeError):
+            parse_date(10)
+
+    def test_parse_date_fails_with_unknown_string(self):
+        with self.assertRaises(TypeError):
+            parse_date("10 F")
 
 
 if __name__ == '__main__':

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -175,7 +175,21 @@ class TestUtilities(unittest.TestCase):
 
     def test_parse_date_fails_int(self):
         with self.assertRaises(TypeError):
-            value = parse_date(10)
+            parse_date(10)
+
+    def test_parse_date_fails_with_unknown_string(self):
+        with self.assertRaises(TypeError):
+            parse_date("10 F")
+
+    def test_date_parse_in_utc(self):
+        value = parse_date("2019-10-1 10:00 MST")
+        value = parse_date(value)
+        self.assertEqual(datetime(2019, 10, 1, 17), value)
+
+    def test_date_parse_returns_tz_unaware(self):
+        value = parse_date("2019-10-1 10:00 MST")
+        value = parse_date(value)
+        self.assertIsNone(value.tzinfo)
 
     def test_parse_date_datetime(self):
         to_convert = datetime(2019, 10, 1)


### PR DESCRIPTION
Hardcode the used timezone for dateparser to be in 'UTC' making it independent from the set time one of the operating system. The returned value by the method will remain timezone unaware.