### PR TITLE
CLI - Fix version retrieval.

### DIFF
--- a/inicheck/cli.py
+++ b/inicheck/cli.py
@@ -3,7 +3,7 @@
 import argparse
 from os.path import abspath, basename, join
 
-from setuptools_scm import get_version
+from importlib.metadata import version, PackageNotFoundError
 
 from .changes import ChangeLog
 from .config import MasterConfig, UserConfig
@@ -13,7 +13,10 @@ from .utilities import *
 
 
 def current_version():
-    return get_version(root='..', relative_to=__file__)
+    try:
+        return version('inicheck')
+    except PackageNotFoundError:
+        'unknown'
 
 
 def main():

--- a/inicheck/cli.py
+++ b/inicheck/cli.py
@@ -1,9 +1,8 @@
 # !/usr/bin/env python
 
 import argparse
+import sys
 from os.path import abspath, basename, join
-
-from importlib.metadata import version, PackageNotFoundError
 
 from .changes import ChangeLog
 from .config import MasterConfig, UserConfig
@@ -13,10 +12,18 @@ from .utilities import *
 
 
 def current_version():
-    try:
-        return version('inicheck')
-    except PackageNotFoundError:
-        'unknown'
+    if sys.version_info >= (3, 8):
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return version('inicheck')
+        except PackageNotFoundError:
+            'unknown'
+    else:
+        from pkg_resources import get_distribution, DistributionNotFound
+        try:
+            return get_distribution('inicheck').version
+        except DistributionNotFound:
+            'unknown'
 
 
 def main():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,10 @@
 
 import unittest
 import sys
+import re
 from os.path import dirname, abspath, join
 
-from inicheck.cli import inicheck_main, inidiff_main
+from inicheck.cli import inicheck_main, inidiff_main, current_version
 
 from .test_output import capture_print
 
@@ -98,6 +99,12 @@ class TestCLI(unittest.TestCase):
 
         mismatches = s.split("config mismatches:")[-1].strip()
         assert '117' in mismatches
+
+    def test_version(self):
+        exception_message = re.search(
+            '(exception|error)', str(current_version()), re.IGNORECASE
+        )
+        assert exception_message  is None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Get version from metadata using `importlib.metadata`, which is part of
the standard libraries.

Fixes #56