### PR TITLE
Issue65

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/inicheck/changes.py
+++ b/inicheck/changes.py
@@ -240,8 +240,9 @@ class ChangeLog(object):
                     del cfg[s_o][i_o]
 
                 # look to remove a whole section
-                if len(cfg[s_o].keys()
-                       ) == 0 and s_o not in ucfg.mcfg.cfg.keys():
-                    del(cfg[s_o])
+                if len(
+                    cfg[s_o].keys()
+                ) == 0 and s_o not in ucfg.mcfg.cfg.keys():
+                    del cfg[s_o]
 
         return cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-dateparser==0.7.2
+dateparser>=1.1.8,<1.2.0
 requests>=2.0.0
+regex>=2021.11.10,<=2023.10.3
 setuptools_scm<4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dateparser>=1.1.8,<1.2.0
+dateparser>=0.7.2,<1.2.0
 requests>=2.0.0
 regex>=2021.11.10,<=2023.10.3
 setuptools_scm<4.2

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.11'
     ],
     use_scm_version={
         'local_scheme': 'node-and-date',


### PR DESCRIPTION
- Constrain regex dependency from dateparser to avoid date parsing issues AND work on M2 chips
- Latest date parser to work on M2 chips
- Test on Python 3.10 and 3.11